### PR TITLE
Add AGENTS with contribution guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+Follow `MIGRATION.md` for incremental steps.
+Use `cargo add` for dependencies rather than editing `Cargo.toml`.
+Run `cargo fmt`, `cargo clippy`, and `cargo test` before each commit.


### PR DESCRIPTION
## Summary
- add `AGENTS.md` with repo contribution guidelines

## Testing
- `cargo fmt` *(fails: could not find `Cargo.toml`)*
- `cargo clippy` *(fails: could not find `Cargo.toml`)*
- `cargo test` *(fails: could not find `Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_686b28c0117c832a9ee5cbfc06ddfac8