### PR TITLE
Implement minimal CLI and GUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,6 +655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -667,6 +668,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-clap = "4.5.40"
+clap = { version = "4.5.40", features = ["derive"] }
 eframe = "0.31.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,7 +8,7 @@ This document outlines a stepwise approach to port the existing .NET codebase to
 4. [x] **Add GUI framework**: `cargo add eframe@0.31.1`.
 5. [x] **Port core structs**: `Species`, `Stats`, `ServerMultipliers`.
 6. [x] **Implement JSON loading tests** to verify data parsing.
-7. [ ] **Build minimal CLI and GUI** that load and display data.
+7. [x] **Build minimal CLI and GUI** that load and display data.
 8. [ ] **Continue porting features** such as the breeding planner, OCR, and other tools.
 
 Each migration step should be kept small, with tests and formatting run after every change to ensure stability.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,0 +1,23 @@
+use ARKStatsExtractor::species::Species;
+use eframe::egui;
+
+pub struct SpeciesApp {
+    species: Vec<Species>,
+}
+
+impl SpeciesApp {
+    pub fn new(species: Vec<Species>) -> Self {
+        Self { species }
+    }
+}
+
+impl eframe::App for SpeciesApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.heading("Species");
+            for s in &self.species {
+                ui.label(&s.name);
+            }
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,15 @@
+#![allow(non_snake_case)]
 pub mod server_multipliers;
 pub mod species;
 pub mod stats;
+
+use serde_json::Value;
+use std::error::Error;
+
+pub fn load_species() -> Result<Vec<species::Species>, Box<dyn Error>> {
+    let data = std::fs::read_to_string("ARKBreedingStats/json/values/values.json")?;
+    let json: Value = serde_json::from_str(&data)?;
+    let species_value = json.get("species").ok_or("missing species")?.clone();
+    let species: Vec<species::Species> = serde_json::from_value(species_value)?;
+    Ok(species)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,33 @@
-fn main() {
-    println!("Hello, world!");
+use ARKStatsExtractor::{load_species, species::Species};
+use clap::Parser;
+
+mod app;
+
+#[derive(Parser)]
+struct Args {
+    /// Launch GUI instead of CLI
+    #[arg(long)]
+    gui: bool,
+}
+
+fn run_cli(species: &[Species]) {
+    for s in species {
+        println!("{}", s.name);
+    }
+}
+
+fn main() -> eframe::Result<()> {
+    let args = Args::parse();
+    let species = load_species().expect("load species");
+    if args.gui {
+        let options = eframe::NativeOptions::default();
+        eframe::run_native(
+            "ARK Stats",
+            options,
+            Box::new(|_cc| Ok(Box::new(app::SpeciesApp::new(species)))),
+        )?;
+    } else {
+        run_cli(&species);
+    }
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- implement a simple `eframe` GUI showing species names
- add CLI argument to print species names or launch GUI
- load species data via new helper function
- mark migration step for CLI/GUI done

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_686b7bb81ee0832a9c6cd8f258c93d05