### PR TITLE
Continue migration: BreedingPair struct

### DIFF
--- a/src/breeding/breeding_pair.rs
+++ b/src/breeding/breeding_pair.rs
@@ -1,0 +1,30 @@
+use crate::{breeding::score::Score, creature::Creature};
+
+#[derive(Debug, Clone)]
+pub struct BreedingPair {
+    pub mother: Creature,
+    pub father: Creature,
+    pub breeding_score: Score,
+    /// Probability of at least one mutation for the offspring.
+    pub mutation_probability: f64,
+    /// The highest possible offspring is over the level limit if all possible dom levels are applied.
+    pub highest_offspring_over_level_limit: bool,
+}
+
+impl BreedingPair {
+    pub fn new(
+        mother: Creature,
+        father: Creature,
+        breeding_score: Score,
+        mutation_probability: f64,
+        highest_offspring_over_level_limit: bool,
+    ) -> Self {
+        Self {
+            mother,
+            father,
+            breeding_score,
+            mutation_probability,
+            highest_offspring_over_level_limit,
+        }
+    }
+}

--- a/src/breeding/mod.rs
+++ b/src/breeding/mod.rs
@@ -1,1 +1,2 @@
+pub mod breeding_pair;
 pub mod score;

--- a/src/creature.rs
+++ b/src/creature.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum Sex {
+    Unknown,
+    Male,
+    Female,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Creature {
+    pub name: String,
+    pub sex: Sex,
+    #[serde(default)]
+    pub mutations: i32,
+}
+
+impl Creature {
+    pub fn new(name: String, sex: Sex, mutations: i32) -> Self {
+        Self {
+            name,
+            sex,
+            mutations,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case)]
 pub mod breeding;
+pub mod creature;
 pub mod server_multipliers;
 pub mod species;
 pub mod stats;

--- a/tests/breeding_pair.rs
+++ b/tests/breeding_pair.rs
@@ -1,0 +1,17 @@
+use ARKStatsExtractor::{
+    breeding::{breeding_pair::BreedingPair, score::Score},
+    creature::{Creature, Sex},
+};
+
+#[test]
+fn breeding_pair_creation() {
+    let mother = Creature::new("Mom".to_string(), Sex::Female, 0);
+    let father = Creature::new("Dad".to_string(), Sex::Male, 0);
+    let score = Score::primary(2.0);
+    let bp = BreedingPair::new(mother.clone(), father.clone(), score, 0.25, false);
+    assert_eq!(bp.mother.name, "Mom");
+    assert_eq!(bp.father.name, "Dad");
+    assert!((bp.mutation_probability - 0.25).abs() < f64::EPSILON);
+    assert!(!bp.highest_offspring_over_level_limit);
+    assert_eq!(bp.breeding_score.one_number(), 2.0);
+}


### PR DESCRIPTION
## Summary
- implement minimal `Creature` with `Sex`
- add `BreedingPair` struct to breeding module
- test `BreedingPair` creation

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686b8412d0e0832a96f5b2ebda357bed