### PR TITLE
Implement basic breeding score

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -11,7 +11,7 @@ This document outlines a stepwise approach to port the existing .NET codebase to
 7. [x] **Build minimal CLI and GUI** that load and display data.
 8. [ ] **Continue porting features** such as the breeding planner, OCR, and other tools.
     - [x] Port `Score` struct from breeding planner.
-    - [ ] Add `Creature` stat fields and implement breeding pair scoring.
+    - [x] Add `Creature` stat fields and implement breeding pair scoring.
 9. [ ] **Persist creature library**.
     - [ ] Serialize and deserialize `Creature` records to JSON.
     - [ ] Provide CLI commands to add/remove creatures.

--- a/src/breeding/breeding_pair.rs
+++ b/src/breeding/breeding_pair.rs
@@ -27,4 +27,19 @@ impl BreedingPair {
             highest_offspring_over_level_limit,
         }
     }
+
+    pub fn from_parents(mother: Creature, father: Creature) -> Self {
+        let breeding_score = calculate_score(&mother, &father);
+        Self::new(mother, father, breeding_score, 0.0, false)
+    }
+}
+
+pub fn calculate_score(mother: &Creature, father: &Creature) -> Score {
+    let total: i32 = mother
+        .stats
+        .iter()
+        .zip(father.stats.iter())
+        .map(|(m, f)| (*m).max(*f))
+        .sum();
+    Score::primary(total as f64)
 }

--- a/src/creature.rs
+++ b/src/creature.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::stats::STATS_COUNT;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum Sex {
     Unknown,
@@ -11,6 +13,7 @@ pub enum Sex {
 pub struct Creature {
     pub name: String,
     pub sex: Sex,
+    pub stats: [i32; STATS_COUNT],
     #[serde(default)]
     pub mutations: i32,
 }
@@ -20,6 +23,16 @@ impl Creature {
         Self {
             name,
             sex,
+            stats: [0; STATS_COUNT],
+            mutations,
+        }
+    }
+
+    pub fn with_stats(name: String, sex: Sex, stats: [i32; STATS_COUNT], mutations: i32) -> Self {
+        Self {
+            name,
+            sex,
+            stats,
             mutations,
         }
     }

--- a/tests/breeding_pair.rs
+++ b/tests/breeding_pair.rs
@@ -1,6 +1,10 @@
 use ARKStatsExtractor::{
-    breeding::{breeding_pair::BreedingPair, score::Score},
+    breeding::{
+        breeding_pair::{BreedingPair, calculate_score},
+        score::Score,
+    },
     creature::{Creature, Sex},
+    stats::STATS_COUNT,
 };
 
 #[test]
@@ -14,4 +18,12 @@ fn breeding_pair_creation() {
     assert!((bp.mutation_probability - 0.25).abs() < f64::EPSILON);
     assert!(!bp.highest_offspring_over_level_limit);
     assert_eq!(bp.breeding_score.one_number(), 2.0);
+}
+
+#[test]
+fn breeding_pair_score_calculation() {
+    let mother = Creature::with_stats("Mom".to_string(), Sex::Female, [10; STATS_COUNT], 0);
+    let father = Creature::with_stats("Dad".to_string(), Sex::Male, [5; STATS_COUNT], 0);
+    let score = calculate_score(&mother, &father);
+    assert_eq!(score, Score::primary((10 * STATS_COUNT as i32) as f64));
 }


### PR DESCRIPTION
## Summary
- add stats field to `Creature`
- compute a simple breeding score
- test breeding score calculation
- mark migration progress

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686b90a67d04832a87b14fc78912cb9d