### PR TITLE
Add creature library persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "eframe",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ clap = { version = "4.5.40", features = ["derive"] }
 eframe = "0.31.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+
+[dev-dependencies]
+tempfile = "3.20.0"

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -12,10 +12,10 @@ This document outlines a stepwise approach to port the existing .NET codebase to
 8. [ ] **Continue porting features** such as the breeding planner, OCR, and other tools.
     - [x] Port `Score` struct from breeding planner.
     - [x] Add `Creature` stat fields and implement breeding pair scoring.
-9. [ ] **Persist creature library**.
-    - [ ] Serialize and deserialize `Creature` records to JSON.
-    - [ ] Provide CLI commands to add/remove creatures.
-    - [ ] Write tests for library persistence.
+9. [x] **Persist creature library**.
+    - [x] Serialize and deserialize `Creature` records to JSON.
+    - [x] Provide CLI commands to add/remove creatures.
+    - [x] Write tests for library persistence.
 10. [ ] **GUI for creature library**.
     - [ ] List creatures with filtering by species and sex.
     - [ ] Allow adding and removing creatures via the GUI.

--- a/src/creature.rs
+++ b/src/creature.rs
@@ -9,7 +9,7 @@ pub enum Sex {
     Female,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Creature {
     pub name: String,
     pub sex: Sex,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 pub mod breeding;
 pub mod creature;
+pub mod library;
 pub mod server_multipliers;
 pub mod species;
 pub mod stats;

--- a/src/library.rs
+++ b/src/library.rs
@@ -1,0 +1,38 @@
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+use crate::creature::Creature;
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct CreatureLibrary {
+    pub creatures: Vec<Creature>,
+}
+
+impl CreatureLibrary {
+    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, Box<dyn std::error::Error>> {
+        if !path.as_ref().exists() {
+            return Ok(Self::default());
+        }
+        let data = std::fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&data)?)
+    }
+
+    pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), Box<dyn std::error::Error>> {
+        let data = serde_json::to_string_pretty(self)?;
+        std::fs::write(path, data)?;
+        Ok(())
+    }
+
+    pub fn add(&mut self, creature: Creature) {
+        self.creatures.push(creature);
+    }
+
+    pub fn remove_by_name(&mut self, name: &str) -> bool {
+        if let Some(pos) = self.creatures.iter().position(|c| c.name == name) {
+            self.creatures.remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,25 +1,72 @@
-use ARKStatsExtractor::{load_species, species::Species};
-use clap::Parser;
+use ARKStatsExtractor::{
+    creature::{Creature, Sex},
+    library::CreatureLibrary,
+    load_species,
+    stats::STATS_COUNT,
+};
+use clap::{Parser, Subcommand};
 
 mod app;
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Add a creature to the library
+    Add {
+        name: String,
+        #[arg(long)]
+        sex: String,
+    },
+    /// Remove a creature from the library by name
+    Remove { name: String },
+}
 
 #[derive(Parser)]
 struct Args {
     /// Launch GUI instead of CLI
     #[arg(long)]
     gui: bool,
+
+    /// Path to creature library JSON file
+    #[arg(long, default_value = "creatures.json")]
+    library: String,
+
+    #[command(subcommand)]
+    command: Option<Commands>,
 }
 
-fn run_cli(species: &[Species]) {
-    for s in species {
-        println!("{}", s.name);
+fn run_cli(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
+    let mut lib = CreatureLibrary::load(&args.library)?;
+    match &args.command {
+        Some(Commands::Add { name, sex }) => {
+            let sex = match sex.to_lowercase().as_str() {
+                "male" | "m" => Sex::Male,
+                "female" | "f" => Sex::Female,
+                _ => Sex::Unknown,
+            };
+            let creature = Creature::with_stats(name.clone(), sex, [0; STATS_COUNT], 0);
+            lib.add(creature);
+            lib.save(&args.library)?;
+        }
+        Some(Commands::Remove { name }) => {
+            if lib.remove_by_name(name) {
+                lib.save(&args.library)?;
+            } else {
+                eprintln!("Creature not found: {name}");
+            }
+        }
+        None => {
+            for c in &lib.creatures {
+                println!("{} ({:?})", c.name, c.sex);
+            }
+        }
     }
+    Ok(())
 }
 
 fn main() -> eframe::Result<()> {
     let args = Args::parse();
-    let species = load_species().expect("load species");
     if args.gui {
+        let species = load_species().expect("load species");
         let options = eframe::NativeOptions::default();
         eframe::run_native(
             "ARK Stats",
@@ -27,7 +74,7 @@ fn main() -> eframe::Result<()> {
             Box::new(|_cc| Ok(Box::new(app::SpeciesApp::new(species)))),
         )?;
     } else {
-        run_cli(&species);
+        run_cli(&args).expect("run cli");
     }
     Ok(())
 }

--- a/tests/library.rs
+++ b/tests/library.rs
@@ -1,0 +1,29 @@
+use ARKStatsExtractor::{
+    creature::{Creature, Sex},
+    library::CreatureLibrary,
+    stats::STATS_COUNT,
+};
+use tempfile::tempdir;
+
+#[test]
+fn save_and_load_library() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("lib.json");
+
+    let mut lib = CreatureLibrary::default();
+    let c = Creature::with_stats("Bob".to_string(), Sex::Male, [1; STATS_COUNT], 0);
+    lib.add(c.clone());
+    lib.save(&file).unwrap();
+
+    let lib2 = CreatureLibrary::load(&file).unwrap();
+    assert_eq!(lib2.creatures.len(), 1);
+    assert_eq!(lib2.creatures[0], c);
+}
+
+#[test]
+fn remove_creature() {
+    let mut lib = CreatureLibrary::default();
+    lib.add(Creature::new("Alice".to_string(), Sex::Female, 0));
+    assert!(lib.remove_by_name("Alice"));
+    assert!(lib.creatures.is_empty());
+}


### PR DESCRIPTION
## Summary
- persist creature library data to/from JSON
- add CLI commands to manage creatures
- implement library tests
- track migration progress

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686b929bc444832a91c8f93357d11224