### PR TITLE
Implement server multiplier profile support

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -20,7 +20,7 @@ This document outlines a stepwise approach to port the existing .NET codebase to
     - [x] List creatures with filtering by species and sex.
     - [x] Allow adding and removing creatures via the GUI.
 11. [ ] **Server multiplier profiles**.
-    - [ ] Parse multiplier files and allow selecting a profile via CLI flag.
+    - [x] Parse multiplier files and allow selecting a profile via CLI flag.
     - [ ] Apply multipliers when calculating stats in the library and breeding planner.
 12. [ ] **Breeding planner implementation**.
     - [ ] Calculate possible offspring levels and mutation chances.

--- a/src/breeding/breeding_pair.rs
+++ b/src/breeding/breeding_pair.rs
@@ -1,4 +1,4 @@
-use crate::{breeding::score::Score, creature::Creature};
+use crate::{breeding::score::Score, creature::Creature, server_multipliers::ServerMultipliers};
 
 #[derive(Debug, Clone)]
 pub struct BreedingPair {
@@ -28,18 +28,43 @@ impl BreedingPair {
         }
     }
 
-    pub fn from_parents(mother: Creature, father: Creature) -> Self {
-        let breeding_score = calculate_score(&mother, &father);
+    pub fn from_parents(
+        mother: Creature,
+        father: Creature,
+        multipliers: Option<&ServerMultipliers>,
+    ) -> Self {
+        let breeding_score = calculate_score(&mother, &father, multipliers);
         Self::new(mother, father, breeding_score, 0.0, false)
     }
 }
 
-pub fn calculate_score(mother: &Creature, father: &Creature) -> Score {
-    let total: i32 = mother
+pub fn calculate_score(
+    mother: &Creature,
+    father: &Creature,
+    multipliers: Option<&ServerMultipliers>,
+) -> Score {
+    let total: f64 = mother
         .stats
         .iter()
         .zip(father.stats.iter())
-        .map(|(m, f)| (*m).max(*f))
+        .enumerate()
+        .map(|(i, (m, f))| {
+            let base = (*m).max(*f) as f64;
+            if let Some(sm) = multipliers {
+                if let Some(stat_mults) = sm
+                    .stat_multipliers
+                    .as_ref()
+                    .and_then(|v| v.get(i))
+                    .and_then(|o| o.as_ref())
+                {
+                    base * stat_mults[ServerMultipliers::INDEX_LEVEL_DOM]
+                } else {
+                    base
+                }
+            } else {
+                base
+            }
+        })
         .sum();
-    Score::primary(total as f64)
+    Score::primary(total)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,3 +16,19 @@ pub fn load_species() -> Result<Vec<species::Species>, Box<dyn Error>> {
     let species: Vec<species::Species> = serde_json::from_value(species_value)?;
     Ok(species)
 }
+
+pub fn load_server_multipliers() -> Result<server_multipliers::ServerMultipliersFile, Box<dyn Error>>
+{
+    let data = std::fs::read_to_string("ARKBreedingStats/json/serverMultipliers.json")?;
+    Ok(serde_json::from_str(&data)?)
+}
+
+pub fn load_server_multipliers_profile(
+    profile: &str,
+) -> Result<server_multipliers::ServerMultipliers, Box<dyn Error>> {
+    let file = load_server_multipliers()?;
+    file.server_multiplier_dictionary
+        .get(profile)
+        .cloned()
+        .ok_or_else(|| format!("unknown profile: {profile}").into())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use ARKStatsExtractor::{
     creature::{Creature, Sex},
     library::CreatureLibrary,
-    load_species,
+    load_server_multipliers_profile, load_species,
     stats::STATS_COUNT,
 };
 use clap::{Parser, Subcommand};
@@ -31,12 +31,17 @@ struct Args {
     #[arg(long, default_value = "creatures.json")]
     library: String,
 
+    /// Server multiplier profile
+    #[arg(long, default_value = "official")]
+    profile: String,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
 
 fn run_cli(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
     let mut lib = CreatureLibrary::load(&args.library)?;
+    let _multipliers = load_server_multipliers_profile(&args.profile)?;
     match &args.command {
         Some(Commands::Add { name, species, sex }) => {
             let sex = match sex.to_lowercase().as_str() {
@@ -70,6 +75,8 @@ fn main() -> eframe::Result<()> {
     if args.gui {
         let species = load_species().expect("load species");
         let lib = CreatureLibrary::load(&args.library).expect("load library");
+        let _multipliers =
+            load_server_multipliers_profile(&args.profile).expect("load multipliers");
         let lib_path = std::path::PathBuf::from(&args.library);
         let options = eframe::NativeOptions::default();
         eframe::run_native(

--- a/src/server_multipliers.rs
+++ b/src/server_multipliers.rs
@@ -47,3 +47,10 @@ pub struct ServerMultipliersFile {
     #[serde(rename = "serverMultiplierDictionary", default)]
     pub server_multiplier_dictionary: std::collections::HashMap<String, ServerMultipliers>,
 }
+
+impl ServerMultipliers {
+    pub const INDEX_TAMING_ADD: usize = 0;
+    pub const INDEX_TAMING_MULT: usize = 1;
+    pub const INDEX_LEVEL_DOM: usize = 2;
+    pub const INDEX_LEVEL_WILD: usize = 3;
+}

--- a/tests/breeding_pair.rs
+++ b/tests/breeding_pair.rs
@@ -4,6 +4,7 @@ use ARKStatsExtractor::{
         score::Score,
     },
     creature::{Creature, Sex},
+    load_server_multipliers_profile,
     stats::STATS_COUNT,
 };
 
@@ -36,6 +37,7 @@ fn breeding_pair_score_calculation() {
         [5; STATS_COUNT],
         0,
     );
-    let score = calculate_score(&mother, &father);
-    assert_eq!(score, Score::primary((10 * STATS_COUNT as i32) as f64));
+    let sm = load_server_multipliers_profile("official").unwrap();
+    let score = calculate_score(&mother, &father, Some(&sm));
+    assert!((score.one_number() - 103.7).abs() < f64::EPSILON);
 }

--- a/tests/json_loading.rs
+++ b/tests/json_loading.rs
@@ -1,4 +1,6 @@
-use ARKStatsExtractor::{server_multipliers::ServerMultipliersFile, species::Species};
+use ARKStatsExtractor::{
+    load_server_multipliers_profile, server_multipliers::ServerMultipliersFile, species::Species,
+};
 
 #[test]
 fn load_species_json() {
@@ -17,4 +19,10 @@ fn load_server_multipliers() {
     let sm: ServerMultipliersFile =
         serde_json::from_str(&data).expect("deserialize server multipliers");
     assert!(sm.server_multiplier_dictionary.contains_key("official"));
+}
+
+#[test]
+fn load_server_multipliers_profile_function() {
+    let sm = load_server_multipliers_profile("singleplayer").unwrap();
+    assert!(sm.mating_interval_multiplier.is_some());
 }


### PR DESCRIPTION
## Summary
- mark first server multiplier profile subtask as done
- add constants and loader functions for server multipliers
- apply multipliers in breeding pair scoring
- expose CLI flag to choose a multiplier profile
- test multiplier profile loading and scoring

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686b97928738832aa4c845210ead2867