### PR TITLE
Implement stat multiplier application

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -21,7 +21,7 @@ This document outlines a stepwise approach to port the existing .NET codebase to
     - [x] Allow adding and removing creatures via the GUI.
 11. [ ] **Server multiplier profiles**.
     - [x] Parse multiplier files and allow selecting a profile via CLI flag.
-    - [ ] Apply multipliers when calculating stats in the library and breeding planner.
+    - [x] Apply multipliers when calculating stats in the library and breeding planner.
 12. [ ] **Breeding planner implementation**.
     - [ ] Calculate possible offspring levels and mutation chances.
     - [ ] Display top scoring breeding pairs in the GUI.

--- a/src/creature.rs
+++ b/src/creature.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::stats::STATS_COUNT;
+use crate::{server_multipliers::ServerMultipliers, stats::STATS_COUNT};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum Sex {
@@ -45,5 +45,29 @@ impl Creature {
             stats,
             mutations,
         }
+    }
+
+    pub fn total_with_multipliers(&self, multipliers: Option<&ServerMultipliers>) -> f64 {
+        self.stats
+            .iter()
+            .enumerate()
+            .map(|(i, s)| {
+                let base = *s as f64;
+                if let Some(sm) = multipliers {
+                    if let Some(stat_mults) = sm
+                        .stat_multipliers
+                        .as_ref()
+                        .and_then(|v| v.get(i))
+                        .and_then(|o| o.as_ref())
+                    {
+                        base * stat_mults[ServerMultipliers::INDEX_LEVEL_DOM]
+                    } else {
+                        base
+                    }
+                } else {
+                    base
+                }
+            })
+            .sum()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ struct Args {
 
 fn run_cli(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
     let mut lib = CreatureLibrary::load(&args.library)?;
-    let _multipliers = load_server_multipliers_profile(&args.profile)?;
+    let multipliers = load_server_multipliers_profile(&args.profile)?;
     match &args.command {
         Some(Commands::Add { name, species, sex }) => {
             let sex = match sex.to_lowercase().as_str() {
@@ -63,7 +63,8 @@ fn run_cli(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
         }
         None => {
             for c in &lib.creatures {
-                println!("{} - {} ({:?})", c.name, c.species, c.sex);
+                let total = c.total_with_multipliers(Some(&multipliers));
+                println!("{} - {} ({:?}) {:.1}", c.name, c.species, c.sex, total);
             }
         }
     }

--- a/tests/creature.rs
+++ b/tests/creature.rs
@@ -1,0 +1,21 @@
+use ARKStatsExtractor::{
+    breeding::breeding_pair::calculate_score,
+    creature::{Creature, Sex},
+    load_server_multipliers_profile,
+    stats::STATS_COUNT,
+};
+
+#[test]
+fn creature_total_with_multipliers() {
+    let c = Creature::with_stats(
+        "Test".to_string(),
+        "Rex".to_string(),
+        Sex::Male,
+        [10; STATS_COUNT],
+        0,
+    );
+    let sm = load_server_multipliers_profile("official").unwrap();
+    let total = c.total_with_multipliers(Some(&sm));
+    let expected = calculate_score(&c, &c, Some(&sm)).one_number();
+    assert!((total - expected).abs() < f64::EPSILON);
+}


### PR DESCRIPTION
## Summary
- mark multiplier application step done in MIGRATION.md
- add method to compute creature stat totals with server multipliers
- show total stats in CLI using selected multipliers
- test multiplier calculations for creatures

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686b9b1bb104832a955e4b02307e0985