### PR TITLE
Implement breeding pair offspring calculations

### DIFF
--- a/src/breeding/breeding_pair.rs
+++ b/src/breeding/breeding_pair.rs
@@ -1,4 +1,7 @@
-use crate::{breeding::score::Score, creature::Creature, server_multipliers::ServerMultipliers};
+use crate::{
+    breeding::score::Score, creature::Creature, server_multipliers::ServerMultipliers,
+    stats::STATS_COUNT,
+};
 
 #[derive(Debug, Clone)]
 pub struct BreedingPair {
@@ -34,7 +37,12 @@ impl BreedingPair {
         multipliers: Option<&ServerMultipliers>,
     ) -> Self {
         let breeding_score = calculate_score(&mother, &father, multipliers);
-        Self::new(mother, father, breeding_score, 0.0, false)
+        let mutation_probability = calculate_mutation_chance(&mother, &father);
+        Self::new(mother, father, breeding_score, mutation_probability, false)
+    }
+
+    pub fn offspring_levels(&self) -> [i32; STATS_COUNT] {
+        possible_offspring_levels(&self.mother, &self.father)
     }
 }
 
@@ -67,4 +75,18 @@ pub fn calculate_score(
         })
         .sum();
     Score::primary(total)
+}
+
+pub fn possible_offspring_levels(mother: &Creature, father: &Creature) -> [i32; STATS_COUNT] {
+    let mut levels = [0; STATS_COUNT];
+    for (i, level) in levels.iter_mut().enumerate().take(STATS_COUNT) {
+        *level = mother.stats[i].max(father.stats[i]);
+    }
+    levels
+}
+
+pub fn calculate_mutation_chance(mother: &Creature, father: &Creature) -> f64 {
+    let m = if mother.mutations < 20 { 0.025 } else { 0.0 };
+    let f = if father.mutations < 20 { 0.025 } else { 0.0 };
+    1.0 - (1.0 - m) * (1.0 - f)
 }

--- a/tests/breeding_pair.rs
+++ b/tests/breeding_pair.rs
@@ -1,6 +1,8 @@
 use ARKStatsExtractor::{
     breeding::{
-        breeding_pair::{BreedingPair, calculate_score},
+        breeding_pair::{
+            BreedingPair, calculate_mutation_chance, calculate_score, possible_offspring_levels,
+        },
         score::Score,
     },
     creature::{Creature, Sex},
@@ -40,4 +42,28 @@ fn breeding_pair_score_calculation() {
     let sm = load_server_multipliers_profile("official").unwrap();
     let score = calculate_score(&mother, &father, Some(&sm));
     assert!((score.one_number() - 103.7).abs() < f64::EPSILON);
+}
+
+#[test]
+fn offspring_levels_and_mutation_chance() {
+    let mother = Creature::with_stats(
+        "Mom".to_string(),
+        "Rex".to_string(),
+        Sex::Female,
+        [10; STATS_COUNT],
+        0,
+    );
+    let father = Creature::with_stats(
+        "Dad".to_string(),
+        "Rex".to_string(),
+        Sex::Male,
+        [8; STATS_COUNT],
+        10,
+    );
+    let pair = BreedingPair::from_parents(mother.clone(), father.clone(), None);
+    let expected_levels = possible_offspring_levels(&mother, &father);
+    assert_eq!(pair.offspring_levels(), expected_levels);
+
+    let expected = calculate_mutation_chance(&mother, &father);
+    assert!((pair.mutation_probability - expected).abs() < f64::EPSILON);
 }


### PR DESCRIPTION
## Summary
- implement functions for computing offspring levels and mutation chance
- calculate mutation probability when building `BreedingPair`
- expose `offspring_levels` method for pairs
- add unit test covering these calculations

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686bb145d39c832a8f479430d403b88b