### PR TITLE
Implement breeding planner step

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -19,13 +19,13 @@ This document outlines a stepwise approach to port the existing .NET codebase to
 10. [x] **GUI for creature library**.
     - [x] List creatures with filtering by species and sex.
     - [x] Allow adding and removing creatures via the GUI.
-11. [ ] **Server multiplier profiles**.
+11. [x] **Server multiplier profiles**.
     - [x] Parse multiplier files and allow selecting a profile via CLI flag.
     - [x] Apply multipliers when calculating stats in the library and breeding planner.
-12. [ ] **Breeding planner implementation**.
-    - [ ] Calculate possible offspring levels and mutation chances.
-    - [ ] Display top scoring breeding pairs in the GUI.
-    - [ ] Unit tests for breeding calculations.
+12. [x] **Breeding planner implementation**.
+    - [x] Calculate possible offspring levels and mutation chances.
+    - [x] Display top scoring breeding pairs in the GUI.
+    - [x] Unit tests for breeding calculations.
 13. [ ] **OCR import**.
     - [ ] Use the `leptess` crate to read creature data from screenshots.
     - [ ] Provide a CLI command and GUI button to trigger OCR import.

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use ARKStatsExtractor::{
     creature::{Creature, Sex},
     library::CreatureLibrary,
+    server_multipliers::ServerMultipliers,
     species::Species,
 };
 
@@ -11,6 +12,7 @@ pub struct LibraryApp {
     library: CreatureLibrary,
     species: Vec<Species>,
     library_path: PathBuf,
+    multipliers: ServerMultipliers,
     filter_species: Option<String>,
     filter_sex: Option<Sex>,
     new_name: String,
@@ -19,11 +21,17 @@ pub struct LibraryApp {
 }
 
 impl LibraryApp {
-    pub fn new(species: Vec<Species>, library: CreatureLibrary, library_path: PathBuf) -> Self {
+    pub fn new(
+        species: Vec<Species>,
+        library: CreatureLibrary,
+        library_path: PathBuf,
+        multipliers: ServerMultipliers,
+    ) -> Self {
         Self {
             library,
             species,
             library_path,
+            multipliers,
             filter_species: None,
             filter_sex: None,
             new_name: String::new(),
@@ -143,6 +151,22 @@ impl eframe::App for LibraryApp {
             if let Some(idx) = remove_index {
                 self.library.creatures.remove(idx);
                 self.save_to_file();
+            }
+
+            ui.separator();
+            ui.heading("Top Breeding Pairs");
+            for pair in self
+                .library
+                .top_breeding_pairs(Some(&self.multipliers), 5)
+                .into_iter()
+            {
+                ui.label(format!(
+                    "{} x {} - {:.1}% chance {:.1}",
+                    pair.mother.name,
+                    pair.father.name,
+                    pair.mutation_probability * 100.0,
+                    pair.breeding_score.one_number()
+                ));
             }
         });
     }

--- a/src/library.rs
+++ b/src/library.rs
@@ -1,7 +1,11 @@
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-use crate::creature::Creature;
+use crate::{
+    breeding::breeding_pair::BreedingPair,
+    creature::{Creature, Sex},
+    server_multipliers::ServerMultipliers,
+};
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct CreatureLibrary {
@@ -34,5 +38,34 @@ impl CreatureLibrary {
         } else {
             false
         }
+    }
+
+    pub fn top_breeding_pairs(
+        &self,
+        multipliers: Option<&ServerMultipliers>,
+        top_n: usize,
+    ) -> Vec<BreedingPair> {
+        let mut pairs = Vec::new();
+        for mother in &self.creatures {
+            if mother.sex != Sex::Female {
+                continue;
+            }
+            for father in &self.creatures {
+                if father.sex != Sex::Male {
+                    continue;
+                }
+                if mother.species != father.species {
+                    continue;
+                }
+                pairs.push(BreedingPair::from_parents(
+                    mother.clone(),
+                    father.clone(),
+                    multipliers,
+                ));
+            }
+        }
+        pairs.sort_by(|a, b| b.breeding_score.cmp(&a.breeding_score));
+        pairs.truncate(top_n);
+        pairs
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,14 +76,20 @@ fn main() -> eframe::Result<()> {
     if args.gui {
         let species = load_species().expect("load species");
         let lib = CreatureLibrary::load(&args.library).expect("load library");
-        let _multipliers =
-            load_server_multipliers_profile(&args.profile).expect("load multipliers");
+        let multipliers = load_server_multipliers_profile(&args.profile).expect("load multipliers");
         let lib_path = std::path::PathBuf::from(&args.library);
         let options = eframe::NativeOptions::default();
         eframe::run_native(
             "ARK Stats",
             options,
-            Box::new(move |_cc| Ok(Box::new(app::LibraryApp::new(species, lib, lib_path)))),
+            Box::new(move |_cc| {
+                Ok(Box::new(app::LibraryApp::new(
+                    species,
+                    lib,
+                    lib_path,
+                    multipliers,
+                )))
+            }),
         )?;
     } else {
         run_cli(&args).expect("run cli");

--- a/tests/library.rs
+++ b/tests/library.rs
@@ -1,6 +1,7 @@
 use ARKStatsExtractor::{
     creature::{Creature, Sex},
     library::CreatureLibrary,
+    server_multipliers::ServerMultipliers,
     stats::STATS_COUNT,
 };
 use tempfile::tempdir;
@@ -37,4 +38,33 @@ fn remove_creature() {
     ));
     assert!(lib.remove_by_name("Alice"));
     assert!(lib.creatures.is_empty());
+}
+
+#[test]
+fn top_breeding_pairs_selects_highest_score() {
+    let mut lib = CreatureLibrary::default();
+    lib.add(Creature::with_stats(
+        "Mom".to_string(),
+        "Rex".to_string(),
+        Sex::Female,
+        [10; STATS_COUNT],
+        0,
+    ));
+    lib.add(Creature::with_stats(
+        "Dad1".to_string(),
+        "Rex".to_string(),
+        Sex::Male,
+        [8; STATS_COUNT],
+        0,
+    ));
+    lib.add(Creature::with_stats(
+        "Dad2".to_string(),
+        "Rex".to_string(),
+        Sex::Male,
+        [12; STATS_COUNT],
+        0,
+    ));
+    let pairs = lib.top_breeding_pairs(Some(&ServerMultipliers::default()), 1);
+    assert_eq!(pairs.len(), 1);
+    assert_eq!(pairs[0].father.name, "Dad2");
 }


### PR DESCRIPTION
## Summary
- implement server multiplier profiles and breeding planner GUI
- display top breeding pairs in the GUI
- provide `top_breeding_pairs` helper in library
- update tests for breeding pair logic
- mark migration steps complete

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686bc1e524a4832abb44005142af1117