### PR TITLE
Add raising times utilities

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod breeding;
 pub mod creature;
 pub mod library;
 pub mod ocr;
+pub mod raising;
 pub mod server_multipliers;
 pub mod species;
 pub mod stats;

--- a/src/raising.rs
+++ b/src/raising.rs
@@ -1,0 +1,53 @@
+use std::time::Duration;
+
+use crate::{
+    server_multipliers::ServerMultipliers,
+    species::{BreedingData, Species},
+};
+
+#[derive(Debug)]
+pub struct RaisingTimes {
+    pub incubation_mode: String,
+    pub incubation: Duration,
+    pub baby: Duration,
+    pub maturation: Duration,
+    pub next_mating_min: Duration,
+    pub next_mating_max: Duration,
+}
+
+pub fn get_raising_times(
+    species: &Species,
+    multipliers: Option<&ServerMultipliers>,
+) -> Option<RaisingTimes> {
+    let breeding: &BreedingData = species.breeding.as_ref()?;
+    let egg_mult = multipliers
+        .and_then(|m| m.egg_hatch_speed_multiplier)
+        .unwrap_or(1.0);
+    let baby_mult = multipliers
+        .and_then(|m| m.baby_mature_speed_multiplier)
+        .unwrap_or(1.0);
+    let interval_mult = multipliers
+        .and_then(|m| m.mating_interval_multiplier)
+        .unwrap_or(1.0);
+
+    let gestation = breeding.gestation_time / egg_mult;
+    let incubation = breeding.incubation_time / egg_mult;
+    let mode = if gestation == 0.0 {
+        "Incubation"
+    } else {
+        "Gestation"
+    };
+    let baby_total = breeding.maturation_time / baby_mult * 0.1;
+    let maturation_total = breeding.maturation_time / baby_mult;
+    let next_min = breeding.mating_cooldown_min * interval_mult;
+    let next_max = breeding.mating_cooldown_max * interval_mult;
+
+    Some(RaisingTimes {
+        incubation_mode: mode.to_string(),
+        incubation: Duration::from_secs_f64(gestation + incubation),
+        baby: Duration::from_secs_f64(baby_total),
+        maturation: Duration::from_secs_f64(maturation_total),
+        next_mating_min: Duration::from_secs_f64(next_min),
+        next_mating_max: Duration::from_secs_f64(next_max),
+    })
+}

--- a/src/species.rs
+++ b/src/species.rs
@@ -9,4 +9,24 @@ pub struct Species {
     pub variants: Vec<String>,
     #[serde(rename = "fullStatsRaw", default)]
     pub full_stats_raw: Vec<Option<[f64; 5]>>,
+    #[serde(default)]
+    pub breeding: Option<BreedingData>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BreedingData {
+    #[serde(rename = "gestationTime", default)]
+    pub gestation_time: f64,
+    #[serde(rename = "incubationTime", default)]
+    pub incubation_time: f64,
+    #[serde(rename = "maturationTime", default)]
+    pub maturation_time: f64,
+    #[serde(rename = "matingCooldownMin", default)]
+    pub mating_cooldown_min: f64,
+    #[serde(rename = "matingCooldownMax", default)]
+    pub mating_cooldown_max: f64,
+    #[serde(rename = "eggTempMin", default)]
+    pub egg_temp_min: Option<f64>,
+    #[serde(rename = "eggTempMax", default)]
+    pub egg_temp_max: Option<f64>,
 }

--- a/tests/raising.rs
+++ b/tests/raising.rs
@@ -1,0 +1,37 @@
+use ARKStatsExtractor::{
+    raising::get_raising_times,
+    server_multipliers::ServerMultipliers,
+    species::{BreedingData, Species},
+};
+
+#[test]
+fn raising_times_basic() {
+    let species = Species {
+        name: "Test".into(),
+        blueprint_path: "path".into(),
+        variants: vec![],
+        full_stats_raw: vec![],
+        breeding: Some(BreedingData {
+            gestation_time: 100.0,
+            incubation_time: 200.0,
+            maturation_time: 1000.0,
+            mating_cooldown_min: 600.0,
+            mating_cooldown_max: 1200.0,
+            egg_temp_min: None,
+            egg_temp_max: None,
+        }),
+    };
+    let mult = ServerMultipliers {
+        egg_hatch_speed_multiplier: Some(2.0),
+        baby_mature_speed_multiplier: Some(4.0),
+        mating_interval_multiplier: Some(0.5),
+        ..Default::default()
+    };
+    let times = get_raising_times(&species, Some(&mult)).unwrap();
+    assert!((times.incubation.as_secs_f64() - 150.0).abs() < f64::EPSILON);
+    assert!((times.baby.as_secs_f64() - 25.0).abs() < f64::EPSILON);
+    assert!((times.maturation.as_secs_f64() - 250.0).abs() < f64::EPSILON);
+    assert!((times.next_mating_min.as_secs_f64() - 300.0).abs() < f64::EPSILON);
+    assert!((times.next_mating_max.as_secs_f64() - 600.0).abs() < f64::EPSILON);
+    assert_eq!(times.incubation_mode, "Gestation");
+}


### PR DESCRIPTION
## Summary
- start implementing raising functionality
- parse `breeding` data from `Species`
- add `raising` module with `get_raising_times`
- test raising time calculations

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686d7e704b84832a896dc4ff0eb61492