### PR TITLE
Implement export and overlay utilities

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -1,0 +1,43 @@
+use std::fs;
+use std::path::Path;
+
+use crate::creature::Creature;
+
+/// Export a creature to a JSON file.
+pub fn export_creature<P: AsRef<Path>>(
+    creature: &Creature,
+    path: P,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let data = serde_json::to_string_pretty(creature)?;
+    fs::write(path, data)?;
+    Ok(())
+}
+
+/// Import a creature from a JSON file.
+pub fn import_creature<P: AsRef<Path>>(path: P) -> Result<Creature, Box<dyn std::error::Error>> {
+    let data = fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&data)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::creature::{Creature, Sex};
+    use crate::stats::STATS_COUNT;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn export_and_import_creature() {
+        let creature = Creature::with_stats(
+            "Bob".to_string(),
+            "Rex".to_string(),
+            Sex::Male,
+            [1; STATS_COUNT],
+            0,
+        );
+        let file = NamedTempFile::new().unwrap();
+        export_creature(&creature, file.path()).unwrap();
+        let loaded = import_creature(file.path()).unwrap();
+        assert_eq!(creature, loaded);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
 #![allow(non_snake_case)]
 pub mod breeding;
 pub mod creature;
+pub mod export;
 pub mod library;
 pub mod ocr;
+pub mod overlay;
 pub mod raising;
 pub mod server_multipliers;
 pub mod species;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use ARKStatsExtractor::{
     creature::{Creature, Sex},
+    export::{export_creature, import_creature},
     library::CreatureLibrary,
     load_server_multipliers_profile, load_species,
     stats::STATS_COUNT,
@@ -21,6 +22,12 @@ enum Commands {
     Remove { name: String },
     /// Import a creature from an image using OCR
     Ocr { image: String },
+    /// Export a creature from the library to a file
+    Export { name: String, file: String },
+    /// Import a creature from a file into the library
+    Import { file: String },
+    /// Show a simple overlay with a message
+    Overlay { message: String },
 }
 
 #[derive(Parser)]
@@ -67,6 +74,30 @@ fn run_cli(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
             let creature = ARKStatsExtractor::ocr::read_creature_from_image(image)?;
             lib.add(creature);
             lib.save(&args.library)?;
+        }
+        Some(Commands::Export { name, file }) => {
+            if let Some(c) = lib.creatures.iter().find(|c| &c.name == name) {
+                export_creature(c, file)?;
+            } else {
+                eprintln!("Creature not found: {name}");
+            }
+        }
+        Some(Commands::Import { file }) => {
+            let creature = import_creature(file)?;
+            lib.add(creature);
+            lib.save(&args.library)?;
+        }
+        Some(Commands::Overlay { message }) => {
+            let options = eframe::NativeOptions::default();
+            eframe::run_native(
+                "Overlay",
+                options,
+                Box::new(move |_cc| {
+                    Ok(Box::new(ARKStatsExtractor::overlay::OverlayApp::new(
+                        message.clone(),
+                    )))
+                }),
+            )?;
         }
         None => {
             for c in &lib.creatures {

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -1,0 +1,19 @@
+use eframe::egui;
+
+pub struct OverlayApp {
+    message: String,
+}
+
+impl OverlayApp {
+    pub fn new(message: String) -> Self {
+        Self { message }
+    }
+}
+
+impl eframe::App for OverlayApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.label(&self.message);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple export module for writing and loading creatures to JSON files
- implement an `OverlayApp` for displaying text as an overlay
- extend the CLI with `export`, `import`, and `overlay` commands

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings` *(fails: `tesseract-sys` build error)*
- `cargo test` *(fails: `tesseract-sys` build error)*

------
https://chatgpt.com/codex/tasks/task_e_686d87496fa8832ab754fb32bb7ef1eb